### PR TITLE
driver/main: Factor out code to constituent functions

### DIFF
--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -331,27 +331,25 @@ int main(int argc, const char** argv)
   }
 
   /* Construct selected tool */
-  size_t ErrorRef = logvisor::ErrorCount;
+  const size_t MakeToolErrorRef = logvisor::ErrorCount;
   auto tool = MakeSelectedTool(argv[1], info);
-
-  if (logvisor::ErrorCount > ErrorRef) {
+  if (logvisor::ErrorCount > MakeToolErrorRef) {
 #if WIN_PAUSE
     system("PAUSE");
 #endif
     return 1;
   }
-
   if (info.verbosityLevel) {
     LogModule.report(logvisor::Info, fmt(_SYS_STR("Constructed tool '{}' {}\n")), tool->toolName(),
                      info.verbosityLevel);
   }
 
   /* Run tool */
-  ErrorRef = logvisor::ErrorCount;
+  const size_t RunToolErrorRef = logvisor::ErrorCount;
   ToolPtr = tool.get();
-  int retval = tool->run();
+  const int retval = tool->run();
   ToolPtr = nullptr;
-  if (logvisor::ErrorCount > ErrorRef) {
+  if (logvisor::ErrorCount > RunToolErrorRef) {
     hecl::blender::Connection::Shutdown();
 #if WIN_PAUSE
     system("PAUSE");


### PR DESCRIPTION
Moves code to its own labeled function to reduce the overall size of the main function, making it nicer to see how all of its functionality is performed. While we're at it, we also fix up any code formatting discrepancies and make use of `std::make_unique` where applicable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/hecl/6)
<!-- Reviewable:end -->
