### PR TITLE
CVar: Remove redundant const return for toLiteral() and toWideLiteral()

### DIFF
--- a/include/hecl/CVar.hpp
+++ b/include/hecl/CVar.hpp
@@ -70,8 +70,8 @@ public:
   float toFloat(bool* isValid = nullptr) const;
   bool toBoolean(bool* isValid = nullptr) const;
   int toInteger(bool* isValid = nullptr) const;
-  const std::wstring toWideLiteral(bool* isValid = nullptr) const;
-  const std::string toLiteral(bool* isValid = nullptr) const;
+  std::wstring toWideLiteral(bool* isValid = nullptr) const;
+  std::string toLiteral(bool* isValid = nullptr) const;
 
   bool fromVec4f(const atVec4f& val);
   bool fromFloat(float val);

--- a/lib/CVar.cpp
+++ b/lib/CVar.cpp
@@ -191,23 +191,25 @@ int CVar::toInteger(bool* isValid) const {
   return strtol(m_value.c_str(), nullptr, 0);
 }
 
-const std::string CVar::toLiteral(bool* isValid) const {
+std::string CVar::toLiteral(bool* isValid) const {
   if (m_type != EType::Literal && (com_developer && com_developer->toBoolean())) {
     if (isValid != nullptr)
       *isValid = false;
-  } else if (isValid != nullptr)
+  } else if (isValid != nullptr) {
     *isValid = true;
+  }
 
   // Even if it's not a literal, it's still safe to return
   return m_value;
 }
 
-const std::wstring CVar::toWideLiteral(bool* isValid) const {
+std::wstring CVar::toWideLiteral(bool* isValid) const {
   if (m_type != EType::Literal && (com_developer && com_developer->toBoolean())) {
     if (isValid != nullptr)
       *isValid = false;
-  } else if (isValid != nullptr)
+  } else if (isValid != nullptr) {
     *isValid = true;
+  }
 
   // Even if it's not a literal, it's still safe to return
   return hecl::UTF8ToWide(m_value);


### PR DESCRIPTION
This can actually inhibit copy elision

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/hecl/10)
<!-- Reviewable:end -->
