### PR TITLE
General: Make operator bool() explicit where applicable

### DIFF
--- a/include/hecl/BitVector.hpp
+++ b/include/hecl/BitVector.hpp
@@ -67,7 +67,7 @@ public:
       return *this;
     }
 
-    operator bool() const { return ((*WordRef) & (BitWord(1) << BitPos)) != 0; }
+    explicit operator bool() const { return ((*WordRef) & (BitWord(1) << BitPos)) != 0; }
   };
 
   /// BitVector default ctor - Creates an empty bitvector.

--- a/include/hecl/Blender/SDNARead.hpp
+++ b/include/hecl/Blender/SDNARead.hpp
@@ -57,7 +57,7 @@ class SDNARead {
 
 public:
   explicit SDNARead(SystemStringView path);
-  operator bool() const { return !m_data.empty(); }
+  explicit operator bool() const { return !m_data.empty(); }
   const SDNABlock& sdnaBlock() const { return m_sdnaBlock; }
   void enumerate(const std::function<bool(const FileBlock& block, athena::io::MemoryReader& r)>& func) const;
 };

--- a/include/hecl/Database.hpp
+++ b/include/hecl/Database.hpp
@@ -246,7 +246,7 @@ private:
 
 public:
   Project(const ProjectRootPath& rootPath);
-  operator bool() const { return m_valid; }
+  explicit operator bool() const { return m_valid; }
 
   /**
    * @brief Configuration file handle

--- a/include/hecl/TypedVariant.hpp
+++ b/include/hecl/TypedVariant.hpp
@@ -173,7 +173,7 @@ public:
     }, static_cast<const base&>(*this));
   }
 
-  constexpr operator bool() const noexcept {
+  constexpr explicit operator bool() const noexcept {
     return !std::holds_alternative<typename std::variant_alternative_t<0, std::variant<_Types...>>>(*this);
   }
 };

--- a/include/hecl/UniformBufferPool.hpp
+++ b/include/hecl/UniformBufferPool.hpp
@@ -153,7 +153,7 @@ public:
       return {bucket.buffer, m_div.rem * m_pool->m_stride};
     }
 
-    operator bool() const { return m_pool != nullptr && m_index != -1; }
+    explicit operator bool() const { return m_pool != nullptr && m_index != -1; }
   };
 
   UniformBufferPool() = default;

--- a/include/hecl/VertexBufferPool.hpp
+++ b/include/hecl/VertexBufferPool.hpp
@@ -158,7 +158,7 @@ public:
       return {bucket.buffer, m_div.rem};
     }
 
-    operator bool() const { return m_pool != nullptr && m_index != -1; }
+    explicit operator bool() const { return m_pool != nullptr && m_index != -1; }
   };
 
   VertexBufferPool() = default;

--- a/include/hecl/hecl.hpp
+++ b/include/hecl/hecl.hpp
@@ -525,7 +525,7 @@ public:
   DirectoryEnumerator(SystemStringView path, Mode mode = Mode::DirsThenFilesSorted, bool sizeSort = false,
                       bool reverse = false, bool noHidden = false);
 
-  operator bool() const { return m_entries.size() != 0; }
+  explicit operator bool() const { return m_entries.size() != 0; }
   size_t size() const { return m_entries.size(); }
   std::vector<Entry>::const_iterator begin() const { return m_entries.cbegin(); }
   std::vector<Entry>::const_iterator end() const { return m_entries.cend(); }
@@ -557,7 +557,7 @@ public:
   /**
    * @brief Tests for non-empty project root path
    */
-  operator bool() const { return m_projRoot.size() != 0; }
+  explicit operator bool() const { return m_projRoot.size() != 0; }
 
   /**
    * @brief Construct a representation of a project root path
@@ -677,7 +677,7 @@ public:
   /**
    * @brief Tests for non-empty project path
    */
-  operator bool() const { return m_absPath.size() != 0; }
+  explicit operator bool() const { return m_absPath.size() != 0; }
 
   /**
    * @brief Clears path

--- a/lib/Pipeline.cpp
+++ b/lib/Pipeline.cpp
@@ -25,7 +25,7 @@ public:
     inflateInit(&m_zstrm);
   }
   ~ShaderCacheZipStream() override { inflateEnd(&m_zstrm); }
-  operator bool() const { return m_compBuf.operator bool(); }
+  explicit operator bool() const { return m_compBuf.operator bool(); }
   atUint64 readUBytesToBuf(void* buf, atUint64 len) override {
     m_zstrm.next_out = (Bytef*)buf;
     m_zstrm.avail_out = len;


### PR DESCRIPTION
Makes conversions to bool slightly less error-prone by requiring them to be explicit in unconventional contexts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/hecl/12)
<!-- Reviewable:end -->
