### PR TITLE
hecl/hecl: Introduce FopenUnique

### DIFF
--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -255,7 +255,7 @@ static std::unique_ptr<ToolBase> MakeSelectedTool(hecl::SystemString toolName, T
     return std::make_unique<ToolHelp>(info);
   }
 
-  std::unique_ptr<FILE, decltype(&std::fclose)> fp{hecl::Fopen(toolName.c_str(), _SYS_STR("rb")), std::fclose};
+  auto fp = hecl::FopenUnique(toolName.c_str(), _SYS_STR("rb"));
   if (fp == nullptr) {
     LogModule.report(logvisor::Error, fmt(_SYS_STR("unrecognized tool '{}'")), toolNameLower);
     return nullptr;

--- a/include/hecl/Database.hpp
+++ b/include/hecl/Database.hpp
@@ -257,7 +257,7 @@ public:
   class ConfigFile {
     SystemString m_filepath;
     std::vector<std::string> m_lines;
-    FILE* m_lockedFile = nullptr;
+    UniqueFilePtr m_lockedFile;
 
   public:
     ConfigFile(const Project& project, SystemStringView name, SystemStringView subdir = _SYS_STR("/.hecl/"));

--- a/include/hecl/hecl.hpp
+++ b/include/hecl/hecl.hpp
@@ -275,6 +275,16 @@ inline FILE* Fopen(const SystemChar* path, const SystemChar* mode, FileLockType 
   return fp;
 }
 
+struct UniqueFileDeleter {
+  void operator()(FILE* file) const noexcept { std::fclose(file); }
+};
+using UniqueFilePtr = std::unique_ptr<FILE, UniqueFileDeleter>;
+
+inline UniqueFilePtr FopenUnique(const SystemChar* path, const SystemChar* mode,
+                                 FileLockType lock = FileLockType::None) {
+  return UniqueFilePtr{Fopen(path, mode, lock)};
+}
+
 inline int FSeek(FILE* fp, int64_t offset, int whence) {
 #if _WIN32
   return _fseeki64(fp, offset, whence);

--- a/lib/Project.cpp
+++ b/lib/Project.cpp
@@ -43,17 +43,19 @@ Project::ConfigFile::ConfigFile(const Project& project, SystemStringView name, S
 }
 
 std::vector<std::string>& Project::ConfigFile::lockAndRead() {
-  if (m_lockedFile)
+  if (m_lockedFile != nullptr) {
     return m_lines;
+  }
 
-  m_lockedFile = hecl::Fopen(m_filepath.c_str(), _SYS_STR("a+"), FileLockType::Write);
-  hecl::FSeek(m_lockedFile, 0, SEEK_SET);
+  m_lockedFile = hecl::FopenUnique(m_filepath.c_str(), _SYS_STR("a+"), FileLockType::Write);
+  hecl::FSeek(m_lockedFile.get(), 0, SEEK_SET);
 
   std::string mainString;
   char readBuf[1024];
   size_t readSz;
-  while ((readSz = fread(readBuf, 1, 1024, m_lockedFile)))
+  while ((readSz = std::fread(readBuf, 1, sizeof(readBuf), m_lockedFile.get()))) {
     mainString += std::string(readBuf, readSz);
+  }
 
   std::string::const_iterator begin = mainString.begin();
   std::string::const_iterator end = mainString.begin();
@@ -110,14 +112,13 @@ bool Project::ConfigFile::checkForLine(std::string_view refLine) {
 }
 
 void Project::ConfigFile::unlockAndDiscard() {
-  if (!m_lockedFile) {
+  if (m_lockedFile == nullptr) {
     LogModule.reportSource(logvisor::Fatal, __FILE__, __LINE__, fmt("Project::ConfigFile::lockAndRead not yet called"));
     return;
   }
 
   m_lines.clear();
-  fclose(m_lockedFile);
-  m_lockedFile = NULL;
+  m_lockedFile.reset();
 }
 
 bool Project::ConfigFile::unlockAndCommit() {
@@ -126,23 +127,22 @@ bool Project::ConfigFile::unlockAndCommit() {
     return false;
   }
 
-  SystemString newPath = m_filepath + _SYS_STR(".part");
-  FILE* newFile = hecl::Fopen(newPath.c_str(), _SYS_STR("w"), FileLockType::Write);
+  const SystemString newPath = m_filepath + _SYS_STR(".part");
+  auto newFile = hecl::FopenUnique(newPath.c_str(), _SYS_STR("w"), FileLockType::Write);
   bool fail = false;
   for (const std::string& line : m_lines) {
-    if (fwrite(line.c_str(), 1, line.size(), newFile) != line.size()) {
+    if (std::fwrite(line.c_str(), 1, line.size(), newFile.get()) != line.size()) {
       fail = true;
       break;
     }
-    if (fwrite("\n", 1, 1, newFile) != 1) {
+    if (std::fputc('\n', newFile.get()) == EOF) {
       fail = true;
       break;
     }
   }
   m_lines.clear();
-  fclose(newFile);
-  fclose(m_lockedFile);
-  m_lockedFile = NULL;
+  newFile.reset();
+  m_lockedFile.reset();
   if (fail) {
 #if HECL_UCS2
     _wunlink(newPath.c_str());
@@ -191,20 +191,21 @@ Project::Project(const ProjectRootPath& rootPath)
   m_cookedRoot.makeDir();
 
   /* Ensure beacon is valid or created */
-  ProjectPath beaconPath(m_dotPath, _SYS_STR("beacon"));
-  FILE* bf = hecl::Fopen(beaconPath.getAbsolutePath().data(), _SYS_STR("a+b"));
+  const ProjectPath beaconPath(m_dotPath, _SYS_STR("beacon"));
+  auto bf = hecl::FopenUnique(beaconPath.getAbsolutePath().data(), _SYS_STR("a+b"));
   struct BeaconStruct {
     hecl::FourCC magic;
     uint32_t version;
   } beacon;
-#define DATA_VERSION 1
-  if (fread(&beacon, 1, sizeof(beacon), bf) != sizeof(beacon)) {
-    fseek(bf, 0, SEEK_SET);
+  constexpr uint32_t DATA_VERSION = 1;
+  if (std::fread(&beacon, 1, sizeof(beacon), bf.get()) != sizeof(beacon)) {
+    std::fseek(bf.get(), 0, SEEK_SET);
     beacon.magic = HECLfcc;
     beacon.version = SBig(DATA_VERSION);
-    fwrite(&beacon, 1, sizeof(beacon), bf);
+    std::fwrite(&beacon, 1, sizeof(beacon), bf.get());
   }
-  fclose(bf);
+  bf.reset();
+
   if (beacon.magic != HECLfcc || SBig(beacon.version) != DATA_VERSION) {
     LogModule.report(logvisor::Fatal, fmt("incompatible project version"));
     return;

--- a/lib/hecl.cpp
+++ b/lib/hecl.cpp
@@ -144,38 +144,38 @@ void ResourceLock::ClearThreadRes() {
 }
 
 bool IsPathPNG(const hecl::ProjectPath& path) {
-  FILE* fp = hecl::Fopen(path.getAbsolutePath().data(), _SYS_STR("rb"));
-  if (!fp)
-    return false;
-  uint32_t buf = 0;
-  if (fread(&buf, 1, 4, fp) != 4) {
-    fclose(fp);
+  const auto fp = hecl::FopenUnique(path.getAbsolutePath().data(), _SYS_STR("rb"));
+  if (fp == nullptr) {
     return false;
   }
-  fclose(fp);
+
+  uint32_t buf = 0;
+  if (std::fread(&buf, 1, sizeof(buf), fp.get()) != sizeof(buf)) {
+    return false;
+  }
+
   buf = hecl::SBig(buf);
-  if (buf == 0x89504e47)
-    return true;
-  return false;
+  return buf == 0x89504e47;
 }
 
 bool IsPathBlend(const hecl::ProjectPath& path) {
-  auto lastCompExt = path.getLastComponentExt();
-  if (lastCompExt.empty() || hecl::StrCmp(lastCompExt.data(), _SYS_STR("blend")))
-    return false;
-  FILE* fp = hecl::Fopen(path.getAbsolutePath().data(), _SYS_STR("rb"));
-  if (!fp)
-    return false;
-  uint32_t buf = 0;
-  if (fread(&buf, 1, 4, fp) != 4) {
-    fclose(fp);
+  const auto lastCompExt = path.getLastComponentExt();
+  if (lastCompExt.empty() || hecl::StrCmp(lastCompExt.data(), _SYS_STR("blend"))) {
     return false;
   }
-  fclose(fp);
+
+  const auto fp = hecl::FopenUnique(path.getAbsolutePath().data(), _SYS_STR("rb"));
+  if (fp == nullptr) {
+    return false;
+  }
+
+  uint32_t buf = 0;
+  if (std::fread(&buf, 1, sizeof(buf), fp.get()) != sizeof(buf)) {
+    return false;
+  }
+
   buf = hecl::SLittle(buf);
-  if (buf == 0x4e454c42 || buf == 0x88b1f)
-    return true;
-  return false;
+  return buf == 0x4e454c42 || buf == 0x88b1f;
 }
 
 bool IsPathYAML(const hecl::ProjectPath& path) {


### PR DESCRIPTION
Provides the exact same semantics as Fopen, but encapsulates the returned memory within a `std::unique_ptr` that automatically closes the file when it goes out of scope (unless explicitly transferred elsewhere). The gets rid of the need to remember to call `std::fclose`.

Ideally, Fclose would have this behavior by default, however Fopen is used in more than just the `hecl` code. So this can't become the case immediately.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/hecl/15)
<!-- Reviewable:end -->
