### PR TITLE
hecl/Compilers: Amend minor string related code

### DIFF
--- a/include/hecl/Compilers.hpp
+++ b/include/hecl/Compilers.hpp
@@ -12,35 +12,35 @@ using PlatformEnum = boo::IGraphicsDataFactory::Platform;
 struct Null {};
 struct OpenGL {
   static constexpr PlatformEnum Enum = PlatformEnum::OpenGL;
-  static const char* Name;
+  static constexpr char Name[] = "OpenGL";
 #if BOO_HAS_GL
   using Context = boo::GLDataFactory::Context;
 #endif
 };
 struct D3D11 {
   static constexpr PlatformEnum Enum = PlatformEnum::D3D11;
-  static const char* Name;
+  static constexpr char Name[] = "D3D11";
 #if _WIN32
   using Context = boo::D3D11DataFactory::Context;
 #endif
 };
 struct Metal {
   static constexpr PlatformEnum Enum = PlatformEnum::Metal;
-  static const char* Name;
+  static constexpr char Name[] = "Metal";
 #if BOO_HAS_METAL
   using Context = boo::MetalDataFactory::Context;
 #endif
 };
 struct Vulkan {
   static constexpr PlatformEnum Enum = PlatformEnum::Vulkan;
-  static const char* Name;
+  static constexpr char Name[] = "Vulkan";
 #if BOO_HAS_VULKAN
   using Context = boo::VulkanDataFactory::Context;
 #endif
 };
 struct NX {
   static constexpr PlatformEnum Enum = PlatformEnum::NX;
-  static const char* Name;
+  static constexpr char Name[] = "NX";
 #if BOO_HAS_NX
   using Context = boo::NXDataFactory::Context;
 #endif
@@ -51,27 +51,27 @@ namespace PipelineStage {
 using StageEnum = boo::PipelineStage;
 struct Null {
   static constexpr StageEnum Enum = StageEnum::Null;
-  static const char* Name;
+  static constexpr char Name[] = "Null";
 };
 struct Vertex {
   static constexpr StageEnum Enum = StageEnum::Vertex;
-  static const char* Name;
+  static constexpr char Name[] = "Vertex";
 };
 struct Fragment {
   static constexpr StageEnum Enum = StageEnum::Fragment;
-  static const char* Name;
+  static constexpr char Name[] = "Fragment";
 };
 struct Geometry {
   static constexpr StageEnum Enum = StageEnum::Geometry;
-  static const char* Name;
+  static constexpr char Name[] = "Geometry";
 };
 struct Control {
   static constexpr StageEnum Enum = StageEnum::Control;
-  static const char* Name;
+  static constexpr char Name[] = "Control";
 };
 struct Evaluation {
   static constexpr StageEnum Enum = StageEnum::Evaluation;
-  static const char* Name;
+  static constexpr char Name[] = "Evaluation";
 };
 } // namespace PipelineStage
 

--- a/lib/Compilers.cpp
+++ b/lib/Compilers.cpp
@@ -17,23 +17,6 @@ extern pD3DCompile D3DCompilePROC;
 namespace hecl {
 logvisor::Module Log("hecl::Compilers");
 
-namespace PlatformType {
-const char* OpenGL::Name = "OpenGL";
-const char* Vulkan::Name = "Vulkan";
-const char* D3D11::Name = "D3D11";
-const char* Metal::Name = "Metal";
-const char* NX::Name = "NX";
-} // namespace PlatformType
-
-namespace PipelineStage {
-const char* Null::Name = "Null";
-const char* Vertex::Name = "Vertex";
-const char* Fragment::Name = "Fragment";
-const char* Geometry::Name = "Geometry";
-const char* Control::Name = "Control";
-const char* Evaluation::Name = "Evaluation";
-} // namespace PipelineStage
-
 template <typename P>
 struct ShaderCompiler {};
 

--- a/lib/Compilers.cpp
+++ b/lib/Compilers.cpp
@@ -167,7 +167,7 @@ struct ShaderCompiler<PlatformType::Metal> {
                "-gline-tables-only", "-MO",
 #endif
                "-", NULL);
-        fprintf(stderr, "execlp fail %s\n", strerror(errno));
+        fmt::print(stderr, fmt("execlp fail {}\n"), strerror(errno));
         exit(1);
       }
       close(compilerIn[0]);
@@ -183,7 +183,7 @@ struct ShaderCompiler<PlatformType::Metal> {
 
         /* metallib doesn't like outputting to a pipe, so temp file will have to do */
         execlp("xcrun", "xcrun", "-sdk", "macosx", "metallib", "-", "-o", libFile.c_str(), NULL);
-        fprintf(stderr, "execlp fail %s\n", strerror(errno));
+        fmt::print(stderr, fmt("execlp fail {}\n"), strerror(errno));
         exit(1);
       }
       close(compilerOut[0]);
@@ -194,7 +194,7 @@ struct ShaderCompiler<PlatformType::Metal> {
       while (inRem) {
         ssize_t writeRes = write(compilerIn[1], inPtr, inRem);
         if (writeRes < 0) {
-          fprintf(stderr, "write fail %s\n", strerror(errno));
+          fmt::print(stderr, fmt("write fail {}\n"), strerror(errno));
           break;
         }
         inPtr += writeRes;
@@ -207,7 +207,7 @@ struct ShaderCompiler<PlatformType::Metal> {
       while (waitpid(compilerPid, &compilerStat, 0) < 0) {
         if (errno == EINTR)
           continue;
-        Log.report(logvisor::Fatal, fmt("waitpid fail %s"), strerror(errno));
+        Log.report(logvisor::Fatal, fmt("waitpid fail {}"), strerror(errno));
         return {};
       }
 
@@ -219,7 +219,7 @@ struct ShaderCompiler<PlatformType::Metal> {
       while (waitpid(linkerPid, &linkerStat, 0) < 0) {
         if (errno == EINTR)
           continue;
-        Log.report(logvisor::Fatal, fmt("waitpid fail %s"), strerror(errno));
+        Log.report(logvisor::Fatal, fmt("waitpid fail {}"), strerror(errno));
         return {};
       }
 

--- a/lib/Compilers.cpp
+++ b/lib/Compilers.cpp
@@ -1,14 +1,17 @@
 #include "hecl/Compilers.hpp"
-#include "boo/graphicsdev/GLSLMacros.hpp"
-#include "logvisor/logvisor.hpp"
+#include <boo/graphicsdev/GLSLMacros.hpp>
+#include <logvisor/logvisor.hpp>
+
 #include <glslang/Public/ShaderLang.h>
 #include <StandAlone/ResourceLimits.h>
 #include <SPIRV/GlslangToSpv.h>
 #include <SPIRV/disassemble.h>
+
 #if _WIN32
 #include <d3dcompiler.h>
 extern pD3DCompile D3DCompilePROC;
 #endif
+
 #if __APPLE__
 #include <unistd.h>
 #include <memory>
@@ -82,7 +85,7 @@ struct ShaderCompiler<PlatformType::D3D11> {
     ComPtr<ID3DBlob> blobOut;
     if (FAILED(D3DCompilePROC(text.data(), text.size(), "Boo HLSL Source", nullptr, nullptr, "main",
                               D3DShaderTypes[int(S::Enum)], BOO_D3DCOMPILE_FLAG, 0, &blobOut, &errBlob))) {
-      printf("%s\n", text.data());
+      fmt::print(fmt("{}\n"), text);
       Log.report(logvisor::Fatal, fmt("error compiling shader: {}"), (char*)errBlob->GetBufferPointer());
       return {};
     }

--- a/lib/Compilers.cpp
+++ b/lib/Compilers.cpp
@@ -110,7 +110,7 @@ struct ShaderCompiler<PlatformType::Metal> {
 
     pid_t pid = fork();
     if (!pid) {
-      execlp("xcrun", "xcrun", "-sdk", "macosx", "metal", "--version", NULL);
+      execlp("xcrun", "xcrun", "-sdk", "macosx", "metal", "--version", nullptr);
       /* xcrun returns 72 if metal command not found;
        * emulate that if xcrun not found */
       exit(72);
@@ -166,7 +166,7 @@ struct ShaderCompiler<PlatformType::Metal> {
 #ifndef NDEBUG
                "-gline-tables-only", "-MO",
 #endif
-               "-", NULL);
+               "-", nullptr);
         fmt::print(stderr, fmt("execlp fail {}\n"), strerror(errno));
         exit(1);
       }
@@ -182,7 +182,7 @@ struct ShaderCompiler<PlatformType::Metal> {
         close(compilerIn[1]);
 
         /* metallib doesn't like outputting to a pipe, so temp file will have to do */
-        execlp("xcrun", "xcrun", "-sdk", "macosx", "metallib", "-", "-o", libFile.c_str(), NULL);
+        execlp("xcrun", "xcrun", "-sdk", "macosx", "metallib", "-", "-o", libFile.c_str(), nullptr);
         fmt::print(stderr, fmt("execlp fail {}\n"), strerror(errno));
         exit(1);
       }


### PR DESCRIPTION
Moves the `Name` string definitions fully inline (as C++17 has inline variables, and constexpr implies inline). While we're at it, we can also convert some usages of printf and fprintf over to fmt.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/hecl/16)
<!-- Reviewable:end -->
