### PR TITLE
hecl: Correct fmt formatting specifiers

### DIFF
--- a/include/hecl/hecl.hpp
+++ b/include/hecl/hecl.hpp
@@ -189,7 +189,7 @@ inline void MakeDir(const char* dir) {
   HRESULT err;
   if (!CreateDirectoryA(dir, NULL))
     if ((err = GetLastError()) != ERROR_ALREADY_EXISTS)
-      LogModule.report(logvisor::Fatal, fmt("MakeDir(%s)"), dir);
+      LogModule.report(logvisor::Fatal, fmt("MakeDir({})"), dir);
 #else
   if (mkdir(dir, 0755))
     if (errno != EEXIST)
@@ -202,7 +202,7 @@ inline void MakeDir(const wchar_t* dir) {
   HRESULT err;
   if (!CreateDirectoryW(dir, NULL))
     if ((err = GetLastError()) != ERROR_ALREADY_EXISTS)
-      LogModule.report(logvisor::Fatal, fmt(_SYS_STR("MakeDir(%s)")), dir);
+      LogModule.report(logvisor::Fatal, fmt(_SYS_STR("MakeDir({})")), dir);
 }
 #endif
 
@@ -370,11 +370,11 @@ inline bool CheckFreeSpace(const SystemChar* path, size_t reqSz) {
   wchar_t* end;
   DWORD ret = GetFullPathNameW(path, 1024, buf, &end);
   if (!ret || ret > 1024)
-    LogModule.report(logvisor::Fatal, fmt(_SYS_STR("GetFullPathNameW %s")), path);
+    LogModule.report(logvisor::Fatal, fmt(_SYS_STR("GetFullPathNameW {}")), path);
   if (end)
     end[0] = L'\0';
   if (!GetDiskFreeSpaceExW(buf, &freeBytes, nullptr, nullptr))
-    LogModule.report(logvisor::Fatal, fmt(_SYS_STR("GetDiskFreeSpaceExW %s: %d")), path, GetLastError());
+    LogModule.report(logvisor::Fatal, fmt(_SYS_STR("GetDiskFreeSpaceExW {}: {}")), path, GetLastError());
   return reqSz < freeBytes.QuadPart;
 #else
   struct statvfs svfs;

--- a/lib/Console.cpp
+++ b/lib/Console.cpp
@@ -368,8 +368,8 @@ void Console::LogVisorAdapter::report(const char* modName, logvisor::Level sever
   auto tmp = fmt::internal::vformat(format, args);
   std::vector<std::string> lines = athena::utility::split(tmp, '\n');
   for (const std::string& line : lines) {
-    auto v = fmt::format(fmt("[%s] %s"), modName, line.c_str());
-    m_con->m_log.emplace_back(v, Console::Level(severity));
+    auto v = fmt::format(fmt("[{}] {}"), modName, line);
+    m_con->m_log.emplace_back(std::move(v), Console::Level(severity));
   }
 }
 
@@ -378,16 +378,16 @@ void Console::LogVisorAdapter::report(const char* modName, logvisor::Level sever
   auto tmp = fmt::internal::vformat(format, args);
   std::vector<std::string> lines = athena::utility::split(athena::utility::wideToUtf8(tmp), '\n');
   for (const std::string& line : lines) {
-    auto v = fmt::format(fmt("[%s] %s"), modName, line.c_str());
-    m_con->m_log.emplace_back(v, Console::Level(severity));
+    auto v = fmt::format(fmt("[{}] {}"), modName, line);
+    m_con->m_log.emplace_back(std::move(v), Console::Level(severity));
   }
 }
 
 void Console::LogVisorAdapter::reportSource(const char* modName, logvisor::Level severity, const char* file,
                                             unsigned linenum, fmt::string_view format, fmt::format_args args) {
   auto tmp = fmt::internal::vformat(format, args);
-  auto v = fmt::format(fmt("[%s] %s %s:%i"), modName, tmp, file, linenum);
-  m_con->m_log.emplace_back(v, Console::Level(severity));
+  auto v = fmt::format(fmt("[{}] {} {}:{}"), modName, tmp, file, linenum);
+  m_con->m_log.emplace_back(std::move(v), Console::Level(severity));
 }
 
 void Console::LogVisorAdapter::reportSource(const char* modName, logvisor::Level severity, const char* file,
@@ -395,8 +395,8 @@ void Console::LogVisorAdapter::reportSource(const char* modName, logvisor::Level
   auto tmp = fmt::internal::vformat(format, args);
   std::vector<std::string> lines = athena::utility::split(athena::utility::wideToUtf8(tmp), '\n');
   for (const std::string& line : lines) {
-    auto v = fmt::format(fmt("[%s] %s %s:%i"), modName, line.c_str(), file, linenum);
-    m_con->m_log.emplace_back(v, Console::Level(severity));
+    auto v = fmt::format(fmt("[{}] {} {}:{}"), modName, line, file, linenum);
+    m_con->m_log.emplace_back(std::move(v), Console::Level(severity));
   }
 }
 

--- a/lib/hecl.cpp
+++ b/lib/hecl.cpp
@@ -779,7 +779,7 @@ int RunProcess(const SystemChar* path, const SystemChar* const args[]) {
       // Display the character read on the screen.
       auto lk = logvisor::LockLog();
       if (!WriteConsoleA(GetStdHandle(STD_OUTPUT_HANDLE), lpBuffer, nBytesRead, &nCharsWritten, NULL)) {
-        // LogModule.report(logvisor::Error, fmt("Error with WriteConsole: %08X"), GetLastError());
+        // LogModule.report(logvisor::Error, fmt("Error with WriteConsole: {:08X}"), GetLastError());
       }
     }
 


### PR DESCRIPTION
These should be using {}-style formatting specifiers instead of printf style. While we're at it, std::move the std::string instances where applicable to potentially avoid reallocations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/hecl/19)
<!-- Reviewable:end -->
