### PR TITLE
hecl/hecl: Minor cleanups

### DIFF
--- a/lib/hecl.cpp
+++ b/lib/hecl.cpp
@@ -690,16 +690,16 @@ int RecursiveMakeDir(const SystemChar* dir) {
 const SystemChar* GetTmpDir() {
 #ifdef _WIN32
 #if WINDOWS_STORE
-  wchar_t* TMPDIR = nullptr;
+  const wchar_t* TMPDIR = nullptr;
 #else
-  wchar_t* TMPDIR = _wgetenv(L"TEMP");
+  const wchar_t* TMPDIR = _wgetenv(L"TEMP");
   if (!TMPDIR)
-    TMPDIR = (wchar_t*)L"\\Temp";
+    TMPDIR = L"\\Temp";
 #endif
 #else
-  char* TMPDIR = getenv("TMPDIR");
+  const char* TMPDIR = getenv("TMPDIR");
   if (!TMPDIR)
-    TMPDIR = (char*)"/tmp";
+    TMPDIR = "/tmp";
 #endif
   return TMPDIR;
 }

--- a/lib/hecl.cpp
+++ b/lib/hecl.cpp
@@ -129,10 +129,8 @@ static std::unordered_map<std::thread::id, ProjectPath> PathsInProgress;
 
 bool ResourceLock::InProgress(const ProjectPath& path) {
   std::unique_lock lk{PathsMutex};
-  for (const auto& p : PathsInProgress)
-    if (p.second == path)
-      return true;
-  return false;
+  return std::any_of(PathsInProgress.cbegin(), PathsInProgress.cend(),
+                     [&path](const auto& entry) { return entry.second == path; });
 }
 
 bool ResourceLock::SetThreadRes(const ProjectPath& path) {

--- a/lib/hecl.cpp
+++ b/lib/hecl.cpp
@@ -24,7 +24,7 @@ namespace hecl {
 unsigned VerbosityLevel = 0;
 bool GuiMode = false;
 logvisor::Module LogModule("hecl");
-static const std::string Illegals{"<>?\""};
+constexpr std::string_view Illegals{"<>?\""};
 
 void SanitizePath(std::string& path) {
   if (path.empty())
@@ -54,7 +54,7 @@ void SanitizePath(std::string& path) {
     path.pop_back();
 }
 
-static const std::wstring WIllegals{L"<>?\""};
+constexpr std::wstring_view WIllegals{L"<>?\""};
 
 void SanitizePath(std::wstring& path) {
   if (path.empty())

--- a/lib/hecl.cpp
+++ b/lib/hecl.cpp
@@ -1,6 +1,14 @@
 #include "hecl/hecl.hpp"
-#include <thread>
+
+#include <algorithm>
+#include <cstdio>
+#include <cstdlib>
+#include <map>
+#include <memory>
 #include <mutex>
+#include <string>
+#include <string_view>
+#include <thread>
 #include <unordered_map>
 
 #ifdef WIN32
@@ -19,6 +27,8 @@
 #include <mntent.h>
 #include <sys/wait.h>
 #endif
+
+#include <logvisor/logvisor.hpp>
 
 namespace hecl {
 unsigned VerbosityLevel = 0;


### PR DESCRIPTION
Performs a few minor cleanups. Notably, getting rid of two static constructors by replacing file-scope string variables with their constexpr view equivalents. The rest are fairly straightforward changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/hecl/20)
<!-- Reviewable:end -->
