### PR TITLE
CVar: std::move listeners within addListener()

### DIFF
--- a/include/hecl/CVar.hpp
+++ b/include/hecl/CVar.hpp
@@ -117,7 +117,7 @@ public:
    */
   void lock();
 
-  void addListener(ListenerFunc func) { m_listeners.push_back(func); }
+  void addListener(ListenerFunc func) { m_listeners.push_back(std::move(func)); }
 
 private:
   void dispatch();


### PR DESCRIPTION
`std::function` is allowed to heap allocate in order to hold any necessary captures, so we should be `std::move`-ing instances here in order to avoid potentially performing reallocations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/hecl/21)
<!-- Reviewable:end -->
