### PR TITLE
hecl/hecl: Remove windows ifdef in CaseInsensitiveCompare

### DIFF
--- a/include/hecl/hecl.hpp
+++ b/include/hecl/hecl.hpp
@@ -503,13 +503,11 @@ struct CaseInsensitiveCompare {
     });
   }
 
-#if _WIN32
   bool operator()(std::wstring_view lhs, std::wstring_view rhs) const {
     return std::lexicographical_compare(lhs.begin(), lhs.end(), rhs.begin(), rhs.end(), [](wchar_t lhs, wchar_t rhs) {
       return std::towlower(lhs) < std::towlower(rhs);
     });
   }
-#endif
 };
 
 /**


### PR DESCRIPTION
This is technically still usable for non-Windows systems, given there's nothing directly Windows-specific about the operator overload

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/hecl/22)
<!-- Reviewable:end -->
