### PR TITLE
Backend: Make ExtensionSlot's constructor constexpr

### DIFF
--- a/include/hecl/Backend.hpp
+++ b/include/hecl/Backend.hpp
@@ -194,7 +194,7 @@ struct Function {
 };
 
 struct ExtensionSlot {
-  const char* shaderMacro;
+  const char* shaderMacro = nullptr;
   size_t texCount = 0;
   const Backend::TextureInfo* texs = nullptr;
   Backend::BlendFactor srcFactor = Backend::BlendFactor::Original;
@@ -209,14 +209,13 @@ struct ExtensionSlot {
   bool forceAlphaTest = false;
   bool diffuseOnly = false;
 
-  ExtensionSlot(size_t texCount = 0,
-                const Backend::TextureInfo* texs = nullptr,
-                Backend::BlendFactor srcFactor = Backend::BlendFactor::Original,
-                Backend::BlendFactor dstFactor = Backend::BlendFactor::Original,
-                Backend::ZTest depthTest = Backend::ZTest::Original,
-                Backend::CullMode cullMode = Backend::CullMode::Backface, bool noDepthWrite = false,
-                bool noColorWrite = false, bool noAlphaWrite = false, bool noAlphaOverwrite = false,
-                bool noReflection = false, bool forceAlphaTest = false, bool diffuseOnly = false)
+  constexpr ExtensionSlot(size_t texCount = 0, const Backend::TextureInfo* texs = nullptr,
+                          Backend::BlendFactor srcFactor = Backend::BlendFactor::Original,
+                          Backend::BlendFactor dstFactor = Backend::BlendFactor::Original,
+                          Backend::ZTest depthTest = Backend::ZTest::Original,
+                          Backend::CullMode cullMode = Backend::CullMode::Backface, bool noDepthWrite = false,
+                          bool noColorWrite = false, bool noAlphaWrite = false, bool noAlphaOverwrite = false,
+                          bool noReflection = false, bool forceAlphaTest = false, bool diffuseOnly = false) noexcept
   : texCount(texCount)
   , texs(texs)
   , srcFactor(srcFactor)


### PR DESCRIPTION
These are used within a file-scope lookup table in urde. Without this, technically those constructors are runtime static constructors.

This allows the compiler to initialize them at compile-time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/hecl/27)
<!-- Reviewable:end -->
