### PR TITLE
TypedVariant: Be explicit about athena's Endian type

### DIFF
--- a/include/hecl/TypedVariant.hpp
+++ b/include/hecl/TypedVariant.hpp
@@ -202,62 +202,67 @@ private:
   TypedVariantBigDNA(TypedVariant<_Types...> var) : TypedVariant<_Types...>(std::move(var)) {}
 };
 
-#define AT_SPECIALIZE_TYPED_VARIANT_BIGDNA(...) \
-template <> \
-template <> \
-inline void hecl::TypedVariantBigDNA<__VA_ARGS__>::Enumerate<athena::io::DNA<athena::Big>::Read>(typename Read::StreamT & r) { \
-  EnumType variant_type = {}; \
-  Do<athena::io::DNA<athena::Big>::Read>(athena::io::PropId("variant_type"), variant_type, r); \
-  static_cast<TypedVariant<__VA_ARGS__>&>(*this) = Build(variant_type); \
-  visit([&](auto& var) { var.read(r); }); \
-} \
- \
-template <> \
-template <> \
-inline void hecl::TypedVariantBigDNA<__VA_ARGS__>::Enumerate<athena::io::DNA<athena::Big>::Write>(typename Write::StreamT & w) { \
-  visit([&](auto& var) { \
-    using T = std::decay_t<decltype(var)>; \
-    EnumType variant_type = T::variant_type(); \
-    Do<athena::io::DNA<athena::Big>::Write>(athena::io::PropId("variant_type"), variant_type, w); \
-    var.write(w); \
-  }); \
-} \
- \
-template <> \
-template <> \
-inline void hecl::TypedVariantBigDNA<__VA_ARGS__>::Enumerate<athena::io::DNA<athena::Big>::BinarySize>(typename BinarySize::StreamT & sz) { \
-  visit([&](auto& var) { \
-    using T = std::decay_t<decltype(var)>; \
-    EnumType variant_type = T::variant_type(); \
-    Do<athena::io::DNA<athena::Big>::BinarySize>(athena::io::PropId("variant_type"), variant_type, sz); \
-    var.binarySize(sz); \
-  }); \
-} \
-template <> \
-inline const char* hecl::TypedVariantBigDNA<__VA_ARGS__>::DNAType() { \
-  return "hecl::TypedVariantBigDNA<" #__VA_ARGS__ ">"; \
-}
+#define AT_SPECIALIZE_TYPED_VARIANT_BIGDNA(...)                                                                        \
+  template <>                                                                                                          \
+  template <>                                                                                                          \
+  inline void hecl::TypedVariantBigDNA<__VA_ARGS__>::Enumerate<athena::io::DNA<athena::Big>::Read>(                    \
+      typename Read::StreamT & r) {                                                                                    \
+    EnumType variant_type = {};                                                                                        \
+    Do<athena::io::DNA<athena::Big>::Read>(athena::io::PropId("variant_type"), variant_type, r);                       \
+    static_cast<TypedVariant<__VA_ARGS__>&>(*this) = Build(variant_type);                                              \
+    visit([&](auto& var) { var.read(r); });                                                                            \
+  }                                                                                                                    \
+                                                                                                                       \
+  template <>                                                                                                          \
+  template <>                                                                                                          \
+  inline void hecl::TypedVariantBigDNA<__VA_ARGS__>::Enumerate<athena::io::DNA<athena::Big>::Write>(                   \
+      typename Write::StreamT & w) {                                                                                   \
+    visit([&](auto& var) {                                                                                             \
+      using T = std::decay_t<decltype(var)>;                                                                           \
+      EnumType variant_type = T::variant_type();                                                                       \
+      Do<athena::io::DNA<athena::Big>::Write>(athena::io::PropId("variant_type"), variant_type, w);                    \
+      var.write(w);                                                                                                    \
+    });                                                                                                                \
+  }                                                                                                                    \
+                                                                                                                       \
+  template <>                                                                                                          \
+  template <>                                                                                                          \
+  inline void hecl::TypedVariantBigDNA<__VA_ARGS__>::Enumerate<athena::io::DNA<athena::Big>::BinarySize>(              \
+      typename BinarySize::StreamT & sz) {                                                                             \
+    visit([&](auto& var) {                                                                                             \
+      using T = std::decay_t<decltype(var)>;                                                                           \
+      EnumType variant_type = T::variant_type();                                                                       \
+      Do<athena::io::DNA<athena::Big>::BinarySize>(athena::io::PropId("variant_type"), variant_type, sz);              \
+      var.binarySize(sz);                                                                                              \
+    });                                                                                                                \
+  }                                                                                                                    \
+  template <>                                                                                                          \
+  inline const char* hecl::TypedVariantBigDNA<__VA_ARGS__>::DNAType() {                                                \
+    return "hecl::TypedVariantBigDNA<" #__VA_ARGS__ ">";                                                               \
+  }
 
-#define AT_SPECIALIZE_TYPED_VARIANT_BIGDNA_YAML(...) \
-AT_SPECIALIZE_TYPED_VARIANT_BIGDNA(__VA_ARGS__) \
-template <> \
-template <> \
-inline void hecl::TypedVariantBigDNA<__VA_ARGS__>::Enumerate<athena::io::DNA<athena::Big>::ReadYaml>(typename ReadYaml::StreamT & r) { \
-  EnumType variant_type = {}; \
-  Do<athena::io::DNA<athena::Big>::ReadYaml>(athena::io::PropId("variant_type"), variant_type, r); \
-  static_cast<TypedVariant<__VA_ARGS__>&>(*this) = Build(variant_type); \
-  visit([&](auto& var) { var.read(r); }); \
-} \
- \
-template <> \
-template <> \
-inline void hecl::TypedVariantBigDNA<__VA_ARGS__>::Enumerate<athena::io::DNA<athena::Big>::WriteYaml>(typename WriteYaml::StreamT & w) { \
-  visit([&](auto& var) { \
-    using T = std::decay_t<decltype(var)>; \
-    EnumType variant_type = T::variant_type(); \
-    Do<athena::io::DNA<athena::Big>::WriteYaml>(athena::io::PropId("variant_type"), variant_type, w); \
-    var.write(w); \
-  }); \
-}
+#define AT_SPECIALIZE_TYPED_VARIANT_BIGDNA_YAML(...)                                                                   \
+  AT_SPECIALIZE_TYPED_VARIANT_BIGDNA(__VA_ARGS__)                                                                      \
+  template <>                                                                                                          \
+  template <>                                                                                                          \
+  inline void hecl::TypedVariantBigDNA<__VA_ARGS__>::Enumerate<athena::io::DNA<athena::Big>::ReadYaml>(                \
+      typename ReadYaml::StreamT & r) {                                                                                \
+    EnumType variant_type = {};                                                                                        \
+    Do<athena::io::DNA<athena::Big>::ReadYaml>(athena::io::PropId("variant_type"), variant_type, r);                   \
+    static_cast<TypedVariant<__VA_ARGS__>&>(*this) = Build(variant_type);                                              \
+    visit([&](auto& var) { var.read(r); });                                                                            \
+  }                                                                                                                    \
+                                                                                                                       \
+  template <>                                                                                                          \
+  template <>                                                                                                          \
+  inline void hecl::TypedVariantBigDNA<__VA_ARGS__>::Enumerate<athena::io::DNA<athena::Big>::WriteYaml>(               \
+      typename WriteYaml::StreamT & w) {                                                                               \
+    visit([&](auto& var) {                                                                                             \
+      using T = std::decay_t<decltype(var)>;                                                                           \
+      EnumType variant_type = T::variant_type();                                                                       \
+      Do<athena::io::DNA<athena::Big>::WriteYaml>(athena::io::PropId("variant_type"), variant_type, w);                \
+      var.write(w);                                                                                                    \
+    });                                                                                                                \
+  }
 
 }

--- a/include/hecl/TypedVariant.hpp
+++ b/include/hecl/TypedVariant.hpp
@@ -205,34 +205,34 @@ private:
 #define AT_SPECIALIZE_TYPED_VARIANT_BIGDNA(...)                                                                        \
   template <>                                                                                                          \
   template <>                                                                                                          \
-  inline void hecl::TypedVariantBigDNA<__VA_ARGS__>::Enumerate<athena::io::DNA<athena::Big>::Read>(                    \
+  inline void hecl::TypedVariantBigDNA<__VA_ARGS__>::Enumerate<athena::io::DNA<athena::Endian::Big>::Read>(            \
       typename Read::StreamT & r) {                                                                                    \
     EnumType variant_type = {};                                                                                        \
-    Do<athena::io::DNA<athena::Big>::Read>(athena::io::PropId("variant_type"), variant_type, r);                       \
+    Do<athena::io::DNA<athena::Endian::Big>::Read>(athena::io::PropId("variant_type"), variant_type, r);               \
     static_cast<TypedVariant<__VA_ARGS__>&>(*this) = Build(variant_type);                                              \
     visit([&](auto& var) { var.read(r); });                                                                            \
   }                                                                                                                    \
                                                                                                                        \
   template <>                                                                                                          \
   template <>                                                                                                          \
-  inline void hecl::TypedVariantBigDNA<__VA_ARGS__>::Enumerate<athena::io::DNA<athena::Big>::Write>(                   \
+  inline void hecl::TypedVariantBigDNA<__VA_ARGS__>::Enumerate<athena::io::DNA<athena::Endian::Big>::Write>(           \
       typename Write::StreamT & w) {                                                                                   \
     visit([&](auto& var) {                                                                                             \
       using T = std::decay_t<decltype(var)>;                                                                           \
       EnumType variant_type = T::variant_type();                                                                       \
-      Do<athena::io::DNA<athena::Big>::Write>(athena::io::PropId("variant_type"), variant_type, w);                    \
+      Do<athena::io::DNA<athena::Endian::Big>::Write>(athena::io::PropId("variant_type"), variant_type, w);            \
       var.write(w);                                                                                                    \
     });                                                                                                                \
   }                                                                                                                    \
                                                                                                                        \
   template <>                                                                                                          \
   template <>                                                                                                          \
-  inline void hecl::TypedVariantBigDNA<__VA_ARGS__>::Enumerate<athena::io::DNA<athena::Big>::BinarySize>(              \
+  inline void hecl::TypedVariantBigDNA<__VA_ARGS__>::Enumerate<athena::io::DNA<athena::Endian::Big>::BinarySize>(      \
       typename BinarySize::StreamT & sz) {                                                                             \
     visit([&](auto& var) {                                                                                             \
       using T = std::decay_t<decltype(var)>;                                                                           \
       EnumType variant_type = T::variant_type();                                                                       \
-      Do<athena::io::DNA<athena::Big>::BinarySize>(athena::io::PropId("variant_type"), variant_type, sz);              \
+      Do<athena::io::DNA<athena::Endian::Big>::BinarySize>(athena::io::PropId("variant_type"), variant_type, sz);      \
       var.binarySize(sz);                                                                                              \
     });                                                                                                                \
   }                                                                                                                    \
@@ -245,22 +245,22 @@ private:
   AT_SPECIALIZE_TYPED_VARIANT_BIGDNA(__VA_ARGS__)                                                                      \
   template <>                                                                                                          \
   template <>                                                                                                          \
-  inline void hecl::TypedVariantBigDNA<__VA_ARGS__>::Enumerate<athena::io::DNA<athena::Big>::ReadYaml>(                \
+  inline void hecl::TypedVariantBigDNA<__VA_ARGS__>::Enumerate<athena::io::DNA<athena::Endian::Big>::ReadYaml>(        \
       typename ReadYaml::StreamT & r) {                                                                                \
     EnumType variant_type = {};                                                                                        \
-    Do<athena::io::DNA<athena::Big>::ReadYaml>(athena::io::PropId("variant_type"), variant_type, r);                   \
+    Do<athena::io::DNA<athena::Endian::Big>::ReadYaml>(athena::io::PropId("variant_type"), variant_type, r);           \
     static_cast<TypedVariant<__VA_ARGS__>&>(*this) = Build(variant_type);                                              \
     visit([&](auto& var) { var.read(r); });                                                                            \
   }                                                                                                                    \
                                                                                                                        \
   template <>                                                                                                          \
   template <>                                                                                                          \
-  inline void hecl::TypedVariantBigDNA<__VA_ARGS__>::Enumerate<athena::io::DNA<athena::Big>::WriteYaml>(               \
+  inline void hecl::TypedVariantBigDNA<__VA_ARGS__>::Enumerate<athena::io::DNA<athena::Endian::Big>::WriteYaml>(       \
       typename WriteYaml::StreamT & w) {                                                                               \
     visit([&](auto& var) {                                                                                             \
       using T = std::decay_t<decltype(var)>;                                                                           \
       EnumType variant_type = T::variant_type();                                                                       \
-      Do<athena::io::DNA<athena::Big>::WriteYaml>(athena::io::PropId("variant_type"), variant_type, w);                \
+      Do<athena::io::DNA<athena::Endian::Big>::WriteYaml>(athena::io::PropId("variant_type"), variant_type, w);        \
       var.write(w);                                                                                                    \
     });                                                                                                                \
   }


### PR DESCRIPTION
Allows this code to still compile if the Endian enum is ever turned into an enum class.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/hecl/29)
<!-- Reviewable:end -->
