### PR TITLE
CVar: Use std::string::empty where applicable

### DIFF
--- a/lib/CVar.cpp
+++ b/lib/CVar.cpp
@@ -80,8 +80,7 @@ CVar::CVar(std::string_view name, uint32_t value, std::string_view help, CVar::E
 }
 
 std::string CVar::help() const {
-  return std::string(m_help + (m_defaultValue != std::string() ? "\ndefault: " + m_defaultValue : "") +
-                     (isReadOnly() ? " [ReadOnly]" : ""));
+  return m_help + (m_defaultValue.empty() ? "" : "\ndefault: " + m_defaultValue) + (isReadOnly() ? " [ReadOnly]" : "");
 }
 
 atVec2f CVar::toVec2f(bool* isValid) const {


### PR DESCRIPTION
We can use empty() instead of comparing against a default constructed new instance.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/hecl/31)
<!-- Reviewable:end -->
