### PR TITLE
Console: Minor changes

### DIFF
--- a/include/hecl/Console.hpp
+++ b/include/hecl/Console.hpp
@@ -108,6 +108,6 @@ public:
   void dumpLog();
   static Console* instance();
   static void RegisterLogger(Console* con);
-  bool isOpen() { return m_state == State::Opened; }
+  bool isOpen() const { return m_state == State::Opened; }
 };
 } // namespace hecl

--- a/include/hecl/Console.hpp
+++ b/include/hecl/Console.hpp
@@ -55,7 +55,7 @@ public:
     Fatal    /**< Non-recoverable error message (Kept for compatibility with logvisor) */
   };
 
-  enum State { Closed, Closing, Opened, Opening };
+  enum class State { Closed, Closing, Opened, Opening };
 
 private:
   CVarManager* m_cvarMgr = nullptr;

--- a/include/hecl/Console.hpp
+++ b/include/hecl/Console.hpp
@@ -89,7 +89,7 @@ public:
 
   void help(Console* con, const std::vector<std::string>& args);
   void listCommands(Console* con, const std::vector<std::string>& args);
-  bool commandExists(std::string_view cmd);
+  bool commandExists(std::string_view cmd) const;
 
   void vreport(Level level, fmt::string_view format, fmt::format_args args);
   template <typename S, typename... Args, typename Char = fmt::char_t<S>>

--- a/include/hecl/Console.hpp
+++ b/include/hecl/Console.hpp
@@ -81,7 +81,7 @@ private:
 public:
   Console(CVarManager*);
   void registerCommand(std::string_view name, std::string_view helpText, std::string_view usage,
-                       const std::function<void(Console*, const std::vector<std::string>&)>&& func,
+                       std::function<void(Console*, const std::vector<std::string>&)>&& func,
                        SConsoleCommand::ECommandFlags cmdFlags = SConsoleCommand::ECommandFlags::Normal);
   void unregisterCommand(std::string_view name);
 

--- a/lib/Console.cpp
+++ b/lib/Console.cpp
@@ -40,12 +40,17 @@ Console::Console(CVarManager* cvarMgr) : m_cvarMgr(cvarMgr), m_overwrite(false),
 }
 
 void Console::registerCommand(std::string_view name, std::string_view helpText, std::string_view usage,
-                              const std::function<void(Console*, const std::vector<std::string>&)>&& func,
+                              std::function<void(Console*, const std::vector<std::string>&)>&& func,
                               SConsoleCommand::ECommandFlags cmdFlags) {
-  std::string lowName = name.data();
+  std::string lowName{name};
   athena::utility::tolower(lowName);
-  if (m_commands.find(lowName) == m_commands.end())
-    m_commands[lowName] = SConsoleCommand{name.data(), helpText.data(), usage.data(), std::move(func), cmdFlags};
+
+  if (m_commands.find(lowName) != m_commands.end()) {
+    return;
+  }
+
+  m_commands.emplace(std::move(lowName), SConsoleCommand{std::string{name}, std::string{helpText}, std::string{usage},
+                                                         std::move(func), cmdFlags});
 }
 
 void Console::unregisterCommand(std::string_view name) {

--- a/lib/Console.cpp
+++ b/lib/Console.cpp
@@ -189,11 +189,11 @@ void Console::init(boo::IWindow* window) {
 
 void Console::proc() {
   if (m_conHeight->isModified()) {
-    m_cachedConHeight = m_conHeight->toReal();
+    m_cachedConHeight = float(m_conHeight->toReal());
   }
 
   if (m_conSpeed->isModified()) {
-    m_cachedConSpeed = m_conSpeed->toReal();
+    m_cachedConSpeed = float(m_conSpeed->toReal());
   }
 
   if (m_state == State::Opened) {

--- a/lib/Console.cpp
+++ b/lib/Console.cpp
@@ -54,10 +54,15 @@ void Console::registerCommand(std::string_view name, std::string_view helpText, 
 }
 
 void Console::unregisterCommand(std::string_view name) {
-  std::string lowName = name.data();
+  std::string lowName{name};
   athena::utility::tolower(lowName);
-  if (m_commands.find(lowName) != m_commands.end())
-    m_commands.erase(m_commands.find(lowName));
+
+  const auto iter = m_commands.find(lowName);
+  if (iter == m_commands.end()) {
+    return;
+  }
+
+  m_commands.erase(iter);
 }
 
 void Console::executeString(const std::string& str) {

--- a/lib/Console.cpp
+++ b/lib/Console.cpp
@@ -19,15 +19,17 @@ Console* Console::m_instance = nullptr;
 Console::Console(CVarManager* cvarMgr) : m_cvarMgr(cvarMgr), m_overwrite(false), m_cursorAtEnd(false) {
   m_instance = this;
   registerCommand("help", "Prints information about a given function", "<command>",
-                  std::bind(&Console::help, this, std::placeholders::_1, std::placeholders::_2));
+                  [this](Console* console, const std::vector<std::string>& args) { help(console, args); });
   registerCommand("listCommands", "Prints a list of all available Commands", "",
-                  std::bind(&Console::listCommands, this, std::placeholders::_1, std::placeholders::_2));
+                  [this](Console* console, const std::vector<std::string>& args) { listCommands(console, args); });
   registerCommand("listCVars", "Lists all available CVars", "",
-                  std::bind(&CVarManager::list, m_cvarMgr, std::placeholders::_1, std::placeholders::_2));
-  registerCommand("setCVar", "Sets a given Console Variable to the specified value", "<cvar> <value>",
-                  std::bind(&CVarManager::setCVar, m_cvarMgr, std::placeholders::_1, std::placeholders::_2));
-  registerCommand("getCVar", "Prints the value stored in the specified Console Variable", "<cvar>",
-                  std::bind(&CVarManager::getCVar, m_cvarMgr, std::placeholders::_1, std::placeholders::_2));
+                  [this](Console* console, const std::vector<std::string>& args) { m_cvarMgr->list(console, args); });
+  registerCommand(
+      "setCVar", "Sets a given Console Variable to the specified value", "<cvar> <value>",
+      [this](Console* console, const std::vector<std::string>& args) { m_cvarMgr->setCVar(console, args); });
+  registerCommand(
+      "getCVar", "Prints the value stored in the specified Console Variable", "<cvar>",
+      [this](Console* console, const std::vector<std::string>& args) { m_cvarMgr->getCVar(console, args); });
   m_conSpeed = cvarMgr->findOrMakeCVar("con_speed",
                                        "Speed at which the console opens and closes, calculated as pixels per second",
                                        1.f, hecl::CVar::EFlags::System | hecl::CVar::EFlags::Archive);

--- a/lib/Console.cpp
+++ b/lib/Console.cpp
@@ -242,8 +242,9 @@ void Console::handleCharCode(unsigned long chr, boo::EModifierKey /*mod*/, bool 
 }
 
 void Console::handleSpecialKeyDown(boo::ESpecialKey sp, boo::EModifierKey mod, bool /*repeat*/) {
-  if (m_state != Opened)
+  if (m_state != State::Opened) {
     return;
+  }
 
   switch (sp) {
   case boo::ESpecialKey::Insert:

--- a/lib/Console.cpp
+++ b/lib/Console.cpp
@@ -177,8 +177,9 @@ bool Console::commandExists(std::string_view cmd) const {
 void Console::vreport(Level level, fmt::string_view fmt, fmt::format_args args) {
   std::string tmp = fmt::vformat(fmt, args);
   std::vector<std::string> lines = athena::utility::split(tmp, '\n');
-  for (const std::string& line : lines)
-    m_log.emplace_back(line, level);
+  for (std::string& line : lines) {
+    m_log.emplace_back(std::move(line), level);
+  }
   fmt::print(fmt("{}\n"), tmp);
 }
 

--- a/lib/Console.cpp
+++ b/lib/Console.cpp
@@ -167,7 +167,7 @@ void Console::listCommands(Console* /*con*/, const std::vector<std::string>& /*a
     report(Level::Info, fmt("'{}': {}"), comPair.second.m_displayName, comPair.second.m_helpString);
 }
 
-bool Console::commandExists(std::string_view cmd) {
+bool Console::commandExists(std::string_view cmd) const {
   std::string cmdName{cmd};
   athena::utility::tolower(cmdName);
 

--- a/lib/Console.cpp
+++ b/lib/Console.cpp
@@ -168,7 +168,7 @@ void Console::listCommands(Console* /*con*/, const std::vector<std::string>& /*a
 }
 
 bool Console::commandExists(std::string_view cmd) {
-  std::string cmdName = cmd.data();
+  std::string cmdName{cmd};
   athena::utility::tolower(cmdName);
 
   return m_commands.find(cmdName) != m_commands.end();


### PR DESCRIPTION
A few minor changes that eliminate some unnecessary copies and strlen() calls from being generated and also allows string_views with non-null-terminated contents to function properly.

While we're in the area we can also make some const qualifier changes and make an enum strongly typed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/hecl/32)
<!-- Reviewable:end -->
