### PR TITLE
hecl/hecl: Allow CaseInsensitiveCompare to be used with heterogenous lookup

### DIFF
--- a/include/hecl/hecl.hpp
+++ b/include/hecl/hecl.hpp
@@ -505,6 +505,9 @@ public:
  * @brief Case-insensitive comparator for std::map sorting
  */
 struct CaseInsensitiveCompare {
+  // Allow heterogenous lookup with maps that use this comparator.
+  using is_transparent = void;
+
   bool operator()(std::string_view lhs, std::string_view rhs) const {
     return std::lexicographical_compare(lhs.begin(), lhs.end(), rhs.begin(), rhs.end(), [](char lhs, char rhs) {
       return std::tolower(static_cast<unsigned char>(lhs)) < std::tolower(static_cast<unsigned char>(rhs));


### PR DESCRIPTION
It's quite common to see maps or sets that make use of a string->object association, usually as `<std::string, T>`. However, this can result in inefficient code when performing lookups or indexing, as something like:

```cpp
std::map<std::string, T> some_map;
...

const auto iter = some_map.find("Name");
...
```

will result in a std::string instance being constructed around "Name", which is less than ideal.

With a heterogenous comparator, however (such as `std::less<>`), like:

```cpp
std::map<std::string, T, std::less<>>
```

we allow the container to do automatic type deduction and comparisons. This allows types comparable to the key type to be used in `find()` calls, etc, without actually needing to construct the key type around the other type.

The main way to enable containers to perform such behavior is by defining a type named `is_transparent` within the comparator type. Given this comparator deals with string views, it being transparent is particularly desirable, since it can operate across multiple string types.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/hecl/33)
<!-- Reviewable:end -->
